### PR TITLE
Adds clearfix

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,9 +5,9 @@ li{
 img{
   width:200px;
   padding-left: 30px;
-  padding-right: 30px;  
+  padding-right: 30px;
 }
-  
+
 h1,h2,h3{
  text-align: center;
 }
@@ -19,7 +19,7 @@ h1,h2,h3{
     width:100%;
 
   }
-  
+
   #grid-floats .grid-item {
     float:left;
     width:22%;
@@ -27,34 +27,34 @@ h1,h2,h3{
     display:block;
     border: 2px solid red;
     margin:10px 0 0 10px;
-   
+
   }
- 
+
   #grid-floats .grid-item:nth-child(1){
     width:45%;
-  } 
+  }
   h2{
     font-size: 30px;
   }
- 
+
 
 /* Flex */
-  
+
 #grid-flex {
   width:100%;
   display:flex;
   flex-direction:row;
   flex-wrap: wrap;
-  
+
 }
 
-.grid-item{ 
+.grid-item{
   border: 2px solid lightblue;
   margin:10px 0 0 10px;
   display: inline-block;
   width:22%;
   flex-grow: 1;
-  
+
 }
 
 .grid-item:nth-child(1){
@@ -68,25 +68,25 @@ h1,h2,h3{
       background-color:brown;
     }
 
-    .grid-item{        
+    .grid-item{
         float:none;
         overflow:hidden;
         width:100%;
         text-align:center;
-        
+
       }
 
     /*float*/
     #grid-floats .grid-item:nth-child(-n + 2){
       width:46%;
   }
-    
+
   #grid-floats .grid-item:nth-last-child(-n +12){
     width:30%;
   }
 }
 /*flex box */
-  
+
   .grid-item:nth-last-child(-n +12){
     width:30%;
   }
@@ -94,20 +94,20 @@ h1,h2,h3{
     width:46%;
   }
   /* for desktop */
-  
+
   @media only screen and (min-width: 1024px) {
     html {
       background-color: green;
     }
     img{
       float:none;
-      overflow:hidden; 
+      overflow:hidden;
     }
 
     #grid-floats .grid-item:nth-last-child(-n +3){
       width:29.70%;
     }
-    
+
     .grid-item:nth-last-child(-n +3){
      width:30%;
     }
@@ -118,13 +118,13 @@ h1,h2,h3{
 
   /*  for mobile */
   @media only screen and (min-width:320px) and (max-width:768px){
-    .grid-item{   
+    .grid-item{
       float:none;
       overflow:hidden;
       width:100%;
       text-align:center;
-    } 
-  
+    }
+
     img{
       width:150px;
     }
@@ -146,9 +146,18 @@ h1,h2,h3{
     .grid-item:nth-child(1){
       width:90%;
    }
- 
+
  .grid-item:nth-last-child(-n +13){
    width:43%;
    height:350px;
  }
+}
+
+section:nth-child(2) {
+  clear: both;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
 }


### PR DESCRIPTION
Good work! 
You were missing the clearfix on the section to avoid the title of the section from coming up, and in the floats,  the thing that you are missing is calculating the width correctly, and remember to add `box-sizing: border-box`, and then calculate the margin around, so to have the 50% and two items with 25%, instead of having `22%` and `45%` you can have `width: calc(50% - 10px)` 10px being the margin, same for the 25% items.

💯 